### PR TITLE
Multiple OS X patches

### DIFF
--- a/patches/binutils-2.25.1/0007-tcarm.diff
+++ b/patches/binutils-2.25.1/0007-tcarm.diff
@@ -1,0 +1,21 @@
+From d840c081f8082e8b9e63fead5306643975a97bb3 Mon Sep 17 00:00:00 2001
+From: Richard Earnshaw <Richard.Earnshaw@arm.com>
+Date: Thu, 20 Nov 2014 17:02:47 +0000
+Subject: [PATCH] * config/tc-arm.c (rotate_left): Avoid undefined behaviour
+ when N = 0.
+
+---
+
+diff --git a/gas/config/tc-arm.c b/gas/config/tc-arm.c
+index 5077f87..9100fb2 100644
+--- a/gas/config/tc-arm.c
++++ b/gas/config/tc-arm.c
+@@ -7251,7 +7251,7 @@ parse_operands (char *str, const unsigned int *pattern, bfd_boolean thumb)
+ 
+ /* Functions for operand encoding.  ARM, then Thumb.  */
+ 
+-#define rotate_left(v, n) (v << n | v >> (32 - n))
++#define rotate_left(v, n) (v << (n & 31) | v >> ((32 - n) & 31))
+ 
+ /* If VAL can be encoded in the immediate field of an ARM instruction,
+    return the encoded form.  Otherwise, return FAIL.  */

--- a/patches/linux-4.4.10/0001-archscripts.diff
+++ b/patches/linux-4.4.10/0001-archscripts.diff
@@ -1,0 +1,12 @@
+diff -u a/Makefile b/Makefile
+--- a/Makefile	2016-05-11 10:23:26.000000000 +0100
++++ b/Makefile	2016-05-20 16:26:20.000000000 +0100
+@@ -1047,7 +1047,7 @@
+ archscripts:
+ 
+ PHONY += __headers
+-__headers: $(version_h) scripts_basic asm-generic archheaders archscripts FORCE
++__headers: $(version_h) scripts_basic asm-generic archheaders FORCE
+ 	$(Q)$(MAKE) $(build)=scripts build_unifdef
+ 
+ PHONY += headers_install_all


### PR DESCRIPTION
With this, and `PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH"` I was able to build for `arm-linux-musleabihf` and `x86_64-linux-musl` on El Capitan.