### PR TITLE
simple canadian cross build support

### DIFF
--- a/config.mak.dist
+++ b/config.mak.dist
@@ -41,11 +41,11 @@
 # ISL_VER =
 # LINUX_VER =
 
-# Something like the following can be used to produce a static-linked
-# toolchain that's deployable to any system with matching arch, using
-# an existing musl-targeted cross compiler. This only # works if the
-# system you build on can natively (or via binfmt_misc and # qemu) run
-# binaries produced by the existing toolchain (in this example, i486).
+# Something like the following can be used to produce a static-linked toolchain
+# that's deployable to any system with matching arch, using an existing
+# musl-targeted cross compiler. This only works if the system you build on can
+# natively (or via binfmt_misc and qemu) run binaries produced by the existing
+# toolchain (in this example, i486).
 
 # COMMON_CONFIG += CC="i486-linux-musl-gcc -static --static" CXX="i486-linux-musl-g++ -static --static"
 

--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -61,16 +61,22 @@ FULL_TOOLCHAIN_CONFIG = --enable-languages=c,c++ \
 FULL_MUSL_CONFIG = $(MUSL_CONFIG) \
 	--prefix= --host=$(TARGET)
 
-ifeq ($(NATIVE),)
+ifneq ($(NATIVE),)
+SYSROOT = /
+FULL_TOOLCHAIN_CONFIG += --host=$(TARGET)
+MUSL_VARS =
+else ifneq ($(CANADIAN),)
+SYSROOT = /$(TARGET)
+FULL_MUSL_CONFIG += CROSS_COMPILE=$(TARGET)- LIBCC="../obj_toolchain/$(TARGET)/libgcc/libgcc.a"
+MUSL_VARS =
+obj_musl/.lc_built: | obj_toolchain/$(TARGET)/libgcc/libgcc.a
+obj_toolchain/.lc_built: | obj_sysroot/.lc_libs obj_sysroot/.lc_headers
+else
 SYSROOT = /$(TARGET)
 FULL_MUSL_CONFIG += CC="$(XGCC)" LIBCC="../obj_toolchain/$(TARGET)/libgcc/libgcc.a" 
 MUSL_VARS = AR=../obj_toolchain/binutils/ar RANLIB=../obj_toolchain/binutils/ranlib
 obj_musl/.lc_built: | obj_toolchain/$(TARGET)/libgcc/libgcc.a
 obj_toolchain/.lc_built: | obj_sysroot/.lc_libs obj_sysroot/.lc_headers
-else
-SYSROOT = /
-FULL_TOOLCHAIN_CONFIG += --host=$(TARGET)
-MUSL_VARS = 
 endif
 
 ifeq ($(TARGET),)


### PR DESCRIPTION
Hi Rich,

Here is a minimal patch to support building a canadian cross compiler if the required build->host and build->target compilers are installed.

Another trivial patch to fix a badly formatted comment.

Patrick

