### PR TITLE
Prune .install and ..install.cmd files from kernel headers

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -205,6 +205,7 @@ src_kernel_headers: | $(LINUX_SRCDIR)
 obj_kernel_headers/.lc_built: | src_kernel_headers
 	mkdir -p $(PWD)/obj_kernel_headers/staged
 	cd src_kernel_headers && $(MAKE) ARCH=$(LINUX_ARCH) O=$(PWD)/obj_kernel_headers INSTALL_HDR_PATH=$(PWD)/obj_kernel_headers/staged headers_install
+	find obj_kernel_headers/staged/include '(' -name .install -o -name ..install.cmd ')' -exec rm {} +
 	touch $@
 install-kernel-headers: | obj_kernel_headers/.lc_built
 	mkdir -p $(DESTDIR)$(OUTPUT)$(SYSROOT)/include


### PR DESCRIPTION
These files aren't useful, especially for a toolchain meant to be relocated, because they contain references to the staging directory and source paths.