### PR TITLE
litecross: build binutils with --enable-deterministic-archives

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -60,6 +60,7 @@ FULL_TOOLCHAIN_CONFIG = --enable-languages=c,c++ \
 	--disable-libmudflap --disable-libsanitizer \
 	--disable-gnu-indirect-function \
 	--disable-libmpx \
+	--enable-deterministic-archives \
 	--enable-libstdcxx-time
 
 FULL_MUSL_CONFIG = $(MUSL_CONFIG) \


### PR DESCRIPTION
as proposed in #26 :

binutils' ar program defaults to creating timestamp in archives, which
breaks reproducible builds.

this misfeature can be explicitly turned off on every usage (-D), or be
disabled completely at build time using the --enable-deterministic-archives
option.

since the former requires patches for every package, having the toolchain
doing the right thing by default seems to be the much better choice.

the configure option is available since binutils 2.20, so it should be
safe to use by now.