### PR TITLE
Fix #31 - building gcc 6.3.0 cross compiler with gcc 7

### DIFF
--- a/patches/gcc-6.3.0/0014-ubsan-empty-string-fix.diff
+++ b/patches/gcc-6.3.0/0014-ubsan-empty-string-fix.diff
@@ -1,0 +1,13 @@
+diff --git a/gcc/ubsan.c b/gcc/ubsan.c
+index 56637d8..1093824 100644
+--- a/gcc/ubsan.c
++++ b/gcc/ubsan.c
+@@ -1471,7 +1471,7 @@ ubsan_use_new_style_p (location_t loc)
+ 
+   expanded_location xloc = expand_location (loc);
+   if (xloc.file == NULL || strncmp (xloc.file, "\1", 2) == 0
+-      || xloc.file == '\0' || xloc.file[0] == '\xff'
++      || xloc.file[0] == '\0' || xloc.file[0] == '\xff'
+       || xloc.file[1] == '\xff')
+     return false;
+ 


### PR DESCRIPTION
Fix #31 

Newer versions of gcc (7+) complain about an empty string check in *gcc/ubsan.c* when trying to build the gcc 6.3.0 cross compiler. The string check has been fixed in later versions of gcc ([revision 239971](https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=239971)), but was never backported to gcc 6.3.0. This pull request adds a patch to *patches/gcc-6.3.0* containing the fix allowing newer versions of gcc to build the gcc 6.3.0 cross compiler.