### PR TITLE
GCC 5.3.0: fix filenames in 0008-shsibcall.diff

### DIFF
--- a/patches/gcc-5.3.0/0008-shsibcall.diff
+++ b/patches/gcc-5.3.0/0008-shsibcall.diff
@@ -1,5 +1,5 @@
---- a/gcc/config/sh/sh.md (revision 233324)
-+++ b/gcc/config/sh/sh.md (working copy)
+--- a/gcc/config/sh/sh.md
++++ b/gcc/config/sh/sh.md
 @@ -10476,7 +10476,7 @@
         (call (mem:SI (match_operand:SI 1 "symbol_ref_operand" ""))
               (match_operand 2 "" "")))


### PR DESCRIPTION
as reported in #15, some patch programs choke on the comments after
the filename...