### PR TITLE
Add ISL and build directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /mpfr-*/
 /build-*/
 /linux-*/
+/isl-*/
+/build/


### PR DESCRIPTION
Noticed that while building I had an ISL directory and a build directory that wasn’t included in the .gitignore. This should enable a clean git tree.