### PR TITLE
Support GMP 6.1.2

### DIFF
--- a/hashes/gmp-6.1.2.tar.bz2.sha1
+++ b/hashes/gmp-6.1.2.tar.bz2.sha1
@@ -1,0 +1,1 @@
+366ded6a44cd108ba6b3f5b9a252eab3f3a95cdf  gmp-6.1.2.tar.bz2


### PR DESCRIPTION
Independent verification of the SHA1 is always appreciated.

Verified compile with the following config.mak:

    TARGET = arm-linux-musleabihf
    BINUTILS_VER = 2.32
    GCC_VER = 8.3.0
    GMP_VER = 6.1.2
    MPC_VER = 1.1.0
    MPFR_VER = 4.0.2
    ISL_VER = 0.21
    LINUX_VER = 3.0.35
    COMMON_CONFIG += --disable-nls
    GCC_CONFIG += --enable-languages=c,c++
    GCC_CONFIG += --disable-libquadmath --disable-decimal-float
    GCC_CONFIG += --disable-multilib