### PR TITLE
Support MPFR 4.0.2

### DIFF
--- a/hashes/mpfr-4.0.2.tar.bz2.sha1
+++ b/hashes/mpfr-4.0.2.tar.bz2.sha1
@@ -1,0 +1,1 @@
+d6a313a3b1ceb9ff3be71cd18e45468837b7fd53  mpfr-4.0.2.tar.bz2


### PR DESCRIPTION
Independent verification of the SHA1 is always appreciated.

Verified compile with the following config.mak:

    TARGET = arm-linux-musleabihf
    BINUTILS_VER = 2.32
    GCC_VER = 8.3.0
    GMP_VER = 6.1.2
    MPC_VER = 1.1.0
    MPFR_VER = 4.0.2
    ISL_VER = 0.21
    LINUX_VER = 3.0.35
    COMMON_CONFIG += --disable-nls
    GCC_CONFIG += --enable-languages=c,c++
    GCC_CONFIG += --disable-libquadmath --disable-decimal-float
    GCC_CONFIG += --disable-multilib