### PR TITLE
default binutils to disable compressed debug info

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -63,6 +63,7 @@ FULL_BINUTILS_CONFIG = \
 	--target=$(TARGET) --prefix= \
 	--libdir=/lib --disable-multilib \
 	--with-sysroot=$(SYSROOT) \
+	--enable-compressed-debug-sections=none \
 	--enable-deterministic-archives
 
 FULL_GCC_CONFIG = --enable-languages=c,c++ \


### PR DESCRIPTION
compressed debug info section is a relatively new feature, and having it on
by default causes link errors when the built libraries (most notably libgcc)
are later used with an older binutils version (for example binutils 2.27,
which was mcm's default version until just recently).