### PR TITLE
add support for sabotage-linux' kernel-headers tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ MUSL_SITE = https://www.musl-libc.org/releases
 MUSL_REPO = git://git.musl-libc.org/musl
 
 LINUX_SITE = https://cdn.kernel.org/pub/linux/kernel
+LINUX_HEADERS_SITE = http://ftp.barfooze.de/pub/sabotage/tarballs/
 
 DL_CMD = wget -c -O
 
@@ -64,6 +65,7 @@ $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/musl*)): SITE = $(MUSL_S
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-4*)): SITE = $(LINUX_SITE)/v4.x
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-3*)): SITE = $(LINUX_SITE)/v3.x
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-2.6*)): SITE = $(LINUX_SITE)/v2.6
+$(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-headers-*)): SITE = $(LINUX_HEADERS_SITE)
 
 $(SOURCES):
 	mkdir -p $@

--- a/hashes/linux-headers-4.4.2-4.tar.xz.sha1
+++ b/hashes/linux-headers-4.4.2-4.tar.xz.sha1
@@ -1,0 +1,1 @@
+f666310bd3d4dfac3e5a93fe4b756efd8fedca05  linux-headers-4.4.2-4.tar.xz


### PR DESCRIPTION
as maintained in https://github.com/sabotage-linux/kernel-headers .

downloading (and extracting) a 100+ MB kernel source tarball just for
the headers is extremely inefficient.
sabotage linux' kernel-headers tarball provides the same (including
musl compatibility fixes) in ~800 KB.

in order to use it, specify

LINUX_VER = headers-4.4.2-4

in your config.mak.

if LINUX_VER lacks the "headers-" prefix, the official source tarball
will be downloaded as usual.