### PR TITLE
add more patches for GCC 4.2.1

### DIFF
--- a/patches/gcc-4.2.1/0013-configureenv.diff
+++ b/patches/gcc-4.2.1/0013-configureenv.diff
@@ -1,0 +1,19 @@
+--- gcc-4.2.1.org/configure
++++ gcc-4.2.1/configure
+@@ -436,6 +436,16 @@
+   -*) { echo "configure: error: $ac_option: invalid option; use --help to show usage" 1>&2; exit 1; }
+     ;;
+ 
++  *=*)
++    ac_envvar=`expr "x$ac_option" : 'x\([^=]*\)='`
++    # Reject names that are not valid shell variable names.
++    case $ac_envvar in #(
++      '' | [0-9]* | *[!_$as_cr_alnum]* )
++      as_fn_error "invalid variable name: \`$ac_envvar'" ;;
++    esac
++    eval $ac_envvar=\$ac_optarg
++    export $ac_envvar ;;
++
+   *)
+     if test -n "`echo $ac_option| sed 's/[-a-z0-9.]//g'`"; then
+       echo "configure: warning: $ac_option: invalid host type" 1>&2

--- a/patches/gcc-4.2.1/0014-cfns-inline-fix.diff
+++ b/patches/gcc-4.2.1/0014-cfns-inline-fix.diff
@@ -1,0 +1,22 @@
+--- gcc-4.2.1.orig/gcc/cp/cfns.h
++++ gcc-4.2.1/gcc/cp/cfns.h
+@@ -37,6 +37,9 @@
+ #ifdef __GNUC__
+ __inline
+ #endif
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 
+@@ -107,6 +110,9 @@
+ 
+ #ifdef __GNUC__
+ __inline
++#endif
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
+ #endif
+ const char *
+ libc_name_p (register const char *str, register unsigned int len)


### PR DESCRIPTION
the first one makes configure compatible with the way mcm calls it (--options mixed with VAR=value assignments, gcc choked on the latter).
second one fixes a build error that happens when a recent GCC is used as the host compiler.
unfortunately, i couldn't get it to build completely, since GCC 4.2.1 insists on building libgcc and crt bits during "stage1" gcc build, which requires that musl's headers are already installed, at which point i decided to use musl-cross instead which has a traditional 2-stage build.
PR is submitted anyway, to document the steps needed to get to that point; maybe someone else will step up to fix the mentioned incompatibility.