### PR TITLE
Add license file and copyright notes

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,16 @@
+Copyright Notes
+===============
+
+The musl-cross-make build tools and documentation are licensed under
+the MIT/Expat license as found in the `LICENSE` file.
+
+Note that this license does not cover the patches (`patches/`) or
+resulting binary artifacts.
+
+Each patch (`patches/`) is distributed under the terms of the license
+of the upstream project to which it is applied.
+
+Similarly, any resulting binary artifacts produced using this build
+tooling retain the original licensing from the upstream projects.  The
+authors of musl-cross-make do not make any additional copyright claims
+to these artifacts.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015-2020 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -145,3 +145,26 @@ build systems, if desired.
 Some functionality (SH/FDPIC, and support for J2 specific features) is
 presently only available with gcc 5.2.0 and later, and binutils 2.25.1
 and later.
+
+License
+-------
+
+The musl-cross-make build tools and documentation are licensed under
+the MIT/Expat license as found in the `LICENSE` file.
+
+Note that this license does not cover the patches (`patches/`) or
+resulting binary artifacts.
+
+Each patch (`patches/`) is distributed under the terms of the license
+of the upstream project to which it is applied.
+
+Similarly, any resulting binary artifacts produced using this build
+tooling retain the original licensing from the upstream projects.  The
+authors of musl-cross-make do not make any additional copyright claims
+to these artifacts.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution submitted for
+inclusion in musl-cross-make by you shall be licensed as above without
+any additional terms or conditions.


### PR DESCRIPTION
After discussion with Rich Felker and other contributors, it's clear
that we want to license this project under the MIT/Expat license.
However, we need to be clear that we're not claiming to license the
binary artifacts, as those retain the licenses of the upstream
projects.  Similarly, the patches, to the extent that there is any
copyright interest in them at all, retain the licenses from the
upstream projects.

We've added language in the README and in a new `COPYRIGHT` file to
make all of this clear.

Ref: #25 #30 #80
