### PR TITLE
Fix initialization of CoW source trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ musl-git-%:
 %: %.orig
 	rm -rf $@.tmp
 	mkdir $@.tmp
-	( cd $@.tmp && find ../$< -path '*/*/*' -prune -exec sh -c 'ln -s "$$@" .' {} + )
+	( cd $@.tmp && find ../$< -path '*/*/*' -prune -exec sh -c 'ln -s "$$@" .' ':' {} + )
 	test ! -d patches/$@ || cat patches/$@/* | ( cd $@.tmp && $(COWPATCH) -p1 )
 	test ! -f $</config.sub || ( rm -f $@.tmp/config.sub && cp -f $(SOURCES)/config.sub $@.tmp/ )
 	mv $@.tmp $@


### PR DESCRIPTION
As part of creating a CoW source tree, we symlink all top-level paths
from the original directory.  In commit ebf93035c, we removed a shell
glob used for this and replaced it with an invocation of `find`.

However, our invocation of `find ... -exec sh -c '... $@ ...' {} \+`
is causing the first path in every directory to be skipped, breaking
the build.  This is because arguments to `sh -c ...` begin with the
zeroth argument, while `$@` only returns the first argument onward.

Let's fix this by providing an explicit zeroth argument to `sh -c`.