### PR TITLE
Configure sha1 hash checklist command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ LINUX_SITE = https://cdn.kernel.org/pub/linux/kernel
 LINUX_HEADERS_SITE = http://ftp.barfooze.de/pub/sabotage/tarballs/
 
 DL_CMD = wget -c -O
+SHA1_CMD = sha1sum -c
 
 COWPATCH = $(PWD)/cowpatch.sh
 
@@ -76,7 +77,7 @@ $(SOURCES)/config.sub: | $(SOURCES)
 	mkdir -p $@.tmp
 	cd $@.tmp && $(DL_CMD) $(notdir $@) "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=$(CONFIG_SUB_REV)"
 	cd $@.tmp && touch $(notdir $@)
-	cd $@.tmp && sha1sum -c $(CURDIR)/hashes/$(notdir $@).$(CONFIG_SUB_REV).sha1
+	cd $@.tmp && $(SHA1_CMD) $(CURDIR)/hashes/$(notdir $@).$(CONFIG_SUB_REV).sha1
 	mv $@.tmp/$(notdir $@) $@
 	rm -rf $@.tmp
 
@@ -84,7 +85,7 @@ $(SOURCES)/%: hashes/%.sha1 | $(SOURCES)
 	mkdir -p $@.tmp
 	cd $@.tmp && $(DL_CMD) $(notdir $@) $(SITE)/$(notdir $@)
 	cd $@.tmp && touch $(notdir $@)
-	cd $@.tmp && sha1sum -c $(CURDIR)/hashes/$(notdir $@).sha1
+	cd $@.tmp && $(SHA1_CMD) $(CURDIR)/hashes/$(notdir $@).sha1
 	mv $@.tmp/$(notdir $@) $@
 	rm -rf $@.tmp
 

--- a/config.mak.dist
+++ b/config.mak.dist
@@ -46,6 +46,13 @@
 # DL_CMD = wget -c -O
 # DL_CMD = curl -C - -L -o
 
+# Check sha-1 hashes of downloaded source archives. On gnu systems this is
+# usually done with sha1sum.
+
+# SHA1_CMD = sha1sum -c
+# SHA1_CMD = sha1 -c
+# SHA1_CMD = shasum -a 1 -c
+
 # Something like the following can be used to produce a static-linked
 # toolchain that's deployable to any system with matching arch, using
 # an existing musl-targeted cross compiler. This only works if the


### PR DESCRIPTION
Currently the Makefile checks sha-1 hashes using `sha1sum` which is a GNU coreutils-ism. Other systems may offer a different command, e.g. `shasum` on macos or `sha1` on *BSDs. This commit extracts the default `sha1sum -c` into a Makefile var `SHA1_CMD` (like what is already done with `DL_CMD` for `wget` v. `curl`) and adds some other possibly useful templates for setting `SHA1_CMD` in the config file template.