### PR TITLE
Use CURDIR instead of PWD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LINUX_HEADERS_SITE = http://ftp.barfooze.de/pub/sabotage/tarballs/
 
 DL_CMD = wget -c -O
 
-COWPATCH = $(PWD)/cowpatch.sh
+COWPATCH = $(CURDIR)/cowpatch.sh
 
 HOST = $(if $(NATIVE),$(TARGET))
 BUILD_DIR = build/$(if $(HOST),$(HOST),local)/$(TARGET)


### PR DESCRIPTION
PWD is set by the shell, not make, and might not match.

For example, this broke the build through Homebrew, because
PWD stays at the directory where brew is ran.