### PR TITLE
Remove unnecessary flags from GCC

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -75,9 +75,7 @@ FULL_GCC_CONFIG = --enable-languages=c,c++ \
 	--libdir=/lib --disable-multilib \
 	--with-sysroot=$(SYSROOT) \
 	--enable-tls \
-	--disable-libmudflap --disable-libsanitizer \
-	--disable-gnu-indirect-function \
-	--disable-libmpx \
+	--disable-libsanitizer \
 	--enable-libstdcxx-time=rt
 
 FULL_MUSL_CONFIG = $(MUSL_CONFIG) \


### PR DESCRIPTION
Here are the flags I removed:

`--disable-libmpx` isn't relevant as MPX support was removed from GCC starting from GCC 9:

<https://gcc.gnu.org/ml/gcc-patches/2018-04/msg01225.html>

`--disable-libmudflap` is also not relevant as the mudflap run time checker was removed starting from GCC 4.9:

<https://gcc.gnu.org/gcc-4.9/changes.html>

`--disable-gnu-indirect-function` is specified by default on non-Glibc hosts (when using musl libc) according to:

<https://gcc.gnu.org/install/configure.html>

> --enable-gnu-indirect-function
Define if you want to enable the ifunc attribute. This option is currently only available on systems with GNU libc on certain targets.

Thanks for your time!