### PR TITLE
Why is MAKEINFO set to false?

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -54,7 +54,7 @@ endif
 MAKE += MULTILIB_OSDIRNAMES=
 MAKE += INFO_DEPS= infodir=
 MAKE += ac_cv_prog_lex_root=lex.yy
-MAKE += MAKEINFO=false
+MAKE += MAKEINFO=true
 
 FULL_BINUTILS_CONFIG = \
 	--disable-separate-code \


### PR DESCRIPTION
I understand that `MAKEINFO=false` works, but `MAKEINFO=true` works better for scripts that fail on error.