### PR TITLE
Don't install headers again

### DIFF
--- a/litecross/Makefile
+++ b/litecross/Makefile
@@ -238,7 +238,7 @@ obj_musl/.lc_built: | obj_musl/.lc_configured
 	touch $@
 
 obj_sysroot/.lc_libs: | obj_musl/.lc_built
-	cd obj_musl && $(MAKE) $(MUSL_VARS) DESTDIR=$(CURDIR)/obj_sysroot install
+	cd obj_musl && $(MAKE) $(MUSL_VARS) DESTDIR=$(CURDIR)/obj_sysroot install-libs install-tools
 	touch $@
 
 obj_gcc/.lc_built: | obj_gcc/.lc_configured obj_gcc/gcc/.lc_built


### PR DESCRIPTION
We already have musl headers installed into `obj_sysroot` with `obj_sysroot/.lc_headers`, so we only need to install the `libs` and `tools`.