### PR TITLE
Add gh-actions build for each os/target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             build/
 
       - name: Build MUSL
-        run: TARGET=${{ matrix.target }} make
+        run: TARGET=${{ matrix.target }} make -j
 
       - name: Package outputs
         run: tar -cf musl-${{ matrix.os }}-${{ matrix.target }}.tgz -C build/local ${{matrix.target}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ master ]
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+    
+    matrix:
+      include:
+        - target=aarch64-linux-musl
+        - target=arm-linux-musleabi
+        - target=arm-linux-musleabihf
+        - target=i686-linux-musl
+        - target=riscv64-linux-musl
+        - target=x86_64-linux-musl
+        - target=x86_64-linux-muslx32
+
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build MUSL
+        run: TARGET=${{ matrix.target }} make
+
+      - name: Package outputs
+        run: tar -C build/local musl-${{ matrix.target }}.tgz ${{matrix.target}}/*
+        
+      - name: Upload utility artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: musl-${{ matrix.target }}.tgz
+          path: musl-${{ matrix.target }}.tgz
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,19 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-20.04
     
-    matrix:
-      include:
-        - target=aarch64-linux-musl
-        - target=arm-linux-musleabi
-        - target=arm-linux-musleabihf
-        - target=i686-linux-musl
-        - target=riscv64-linux-musl
-        - target=x86_64-linux-musl
-        - target=x86_64-linux-muslx32
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-linux-musl
+          - target: arm-linux-musleabi
+          - target: arm-linux-musleabihf
+          - target: i686-linux-musl
+          - target: riscv64-linux-musl
+          - target: x86_64-linux-musl
+          - target: x86_64-linux-muslx32
 
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,27 @@ on:
     branches: [ master ]
 
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: aarch64-linux-musl
-          - target: arm-linux-musleabi
-          - target: arm-linux-musleabihf
-          - target: i686-linux-musl
-          - target: riscv64-linux-musl
-          - target: x86_64-linux-musl
-          - target: x86_64-linux-muslx32
-
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        target:
+          - aarch64-linux-musl
+          - arm-linux-musleabi
+          - arm-linux-musleabihf
+          - i686-linux-musl
+          - riscv64-linux-musl
+          - x86_64-linux-musl
+          - x86_64-linux-muslx32
 
     steps:
       - uses: actions/checkout@v2
@@ -35,11 +38,11 @@ jobs:
         run: TARGET=${{ matrix.target }} make
 
       - name: Package outputs
-        run: tar -C build/local musl-${{ matrix.target }}.tgz ${{matrix.target}}/*
+        run: tar -C build/local musl-${{ matrix.os }}-${{ matrix.target }}.tgz ${{matrix.target}}/*
         
-      - name: Upload utility artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: musl-${{ matrix.target }}.tgz
-          path: musl-${{ matrix.target }}.tgz
+          name: musl-${{ matrix.os }}-${{ matrix.target }}.tgz
+          path: musl-${{ matrix.os }}-${{ matrix.target }}.tgz
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        
+      - name: Configure caching 
+        uses: actions/cache@v2
+        # Caching disabled on macos due to https://github.com/actions/cache/issues/403
+        if: ${{ matrix.os != 'macos-latest' }}
+        with:
+          key: ${{ matrix.os }}-${{ matrix.target }}
+          path: |
+            Sources/
+            output/
+            binutils-*/
+            gcc-*/
+            musl-*/
+            gmp-*/
+            mpc-*/
+            mpfr-*/
+            build-*/
+            linux-*/
+            isl-*/
+            build/
 
       - name: Build MUSL
         run: TARGET=${{ matrix.target }} make
 
       - name: Package outputs
-        run: tar -C build/local musl-${{ matrix.os }}-${{ matrix.target }}.tgz ${{matrix.target}}/*
+        run: tar -cf musl-${{ matrix.os }}-${{ matrix.target }}.tgz -C build/local ${{matrix.target}}
         
       - name: Upload artifacts
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Hey there, thanks for maintaining this!

After rather a slow build I wondered if you might be interested in adding CI publish pre-compiled objects?
This is just a first pass (which probably won't work yet), but I figured it was worth asking first. Still to:

- [ ] Build for non-linux base systems
- [ ] Work out how to create a _useful_ archive file (ie. directories such that this can be extracted in an equivalend manner to `make install`, a prefix for install or something would enable this?)
- [ ] Actually link the archive tile to a release on tags
- [ ] Cache downloads / deps where viable to speed up re-builds

See https://github.com/ryankurte/musl-cross-make/pull/1 for actions execution (under my account, won't happen here until merged I think)
