### PR TITLE
allow specifying extra patch directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ musl-git-%:
 	mkdir $@.tmp
 	( cd $@.tmp && $(COWPATCH) -I ../$< )
 	test ! -d patches/$@ || cat patches/$@/* | ( cd $@.tmp && $(COWPATCH) -p1 )
+	if [ ! -z "$(EXTRA_PATCHES)" ]; then cat $(EXTRA_PATCHES)/$@/* | ( cd $@.tmp && $(COWPATCH) -p1 ); fi
 	if test -f $</configfsf.sub ; then cs=configfsf.sub ; elif test -f $</config.sub ; then cs=config.sub ; else exit 0 ; fi ; rm -f $@.tmp/$$cs && cp -f $(SOURCES)/config.sub $@.tmp/$$cs && chmod +x $@.tmp/$$cs
 	rm -rf $@
 	mv $@.tmp $@


### PR DESCRIPTION
This commit allows the user to specify an extra patch directory by
either placing EXTRA_PATCHES in the config.mak or as an environment
variable when invoking make.

The patch directory is expected to have the same structure as the
patches/ directory, thus having subdirectories with the respective
components (gcc, musl, ...) and their version.

Providing EXTRA_PATCHES is optional.

Having extra patches allows to specify custom MUSL patches without
dirtying the musl-cross-make repository directory.