### PR TITLE
GCC Snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MPFR_VER = 4.0.2
 LINUX_VER = headers-4.19.88-1
 
 GNU_SITE = https://ftpmirror.gnu.org/gnu
+GCC_SNAP = https://gcc.gnu.org/pub/gcc/snapshots
 GCC_SITE = $(GNU_SITE)/gcc
 BINUTILS_SITE = $(GNU_SITE)/binutils
 GMP_SITE = $(GNU_SITE)/gmp
@@ -63,7 +64,8 @@ $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/mpc*)): SITE = $(MPC_SIT
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/mpfr*)): SITE = $(MPFR_SITE)
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/isl*)): SITE = $(ISL_SITE)
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/binutils*)): SITE = $(BINUTILS_SITE)
-$(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/gcc*)): SITE = $(GCC_SITE)/$(basename $(basename $(notdir $@)))
+$(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/gcc-*)): SITE = $(GCC_SITE)/$(basename $(basename $(notdir $@)))
+$(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/gcc-*-*)): SITE = $(GCC_SNAP)/$(subst gcc-,,$(basename $(basename $(notdir $@))))
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/musl*)): SITE = $(MUSL_SITE)
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-5*)): SITE = $(LINUX_SITE)/v5.x
 $(patsubst hashes/%.sha1,$(SOURCES)/%,$(wildcard hashes/linux-4*)): SITE = $(LINUX_SITE)/v4.x


### PR DESCRIPTION
Allows the user to specify a `gcc` snapshot version, from https://gcc.gnu.org/pub/gcc/snapshots, or a mirror of, as the `gcc` version in the `config.mak` by setting it as the `GCC_VER `, for example

 `GCC_VER = 14-20240310` 

and use version of `gcc` to build the toolchain

source: https://git.zv.io/toolchains/musl-cross-make/-/blob/musl.cc/Makefile?ref_type=heads#L67-L68