### PR TITLE
bump linux-headers to 4.19.88-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MUSL_VER = 1.2.5
 GMP_VER = 6.1.2
 MPC_VER = 1.1.0
 MPFR_VER = 4.0.2
-LINUX_VER = headers-4.19.88-1
+LINUX_VER = headers-4.19.88-2
 
 GNU_SITE = https://ftpmirror.gnu.org/gnu
 GCC_SITE = $(GNU_SITE)/gcc

--- a/hashes/linux-headers-4.19.88-2.tar.xz.sha1
+++ b/hashes/linux-headers-4.19.88-2.tar.xz.sha1
@@ -1,0 +1,1 @@
+9794861f8ec91398d07694fe8a5651f9a466b967  linux-headers-4.19.88-2.tar.xz


### PR DESCRIPTION
this adds support for riscv and fixes a bug in swab.h, allowing to build newer kernels - the objtool component is built using host kernel headers, not the ones available in-tree.