### PR TITLE
Fix GCC 11.4.0 build on hosts with GCC 14

### DIFF
--- a/patches/gcc-11.4.0/0010-libiberty-fix.diff
+++ b/patches/gcc-11.4.0/0010-libiberty-fix.diff
@@ -1,0 +1,13 @@
+diff --git a/libiberty/simple-object-mach-o.c b/libiberty/simple-object-mach-o.c
+index 72b69d19c216..a8869e7c6395 100644
+--- a/libiberty/simple-object-mach-o.c
++++ b/libiberty/simple-object-mach-o.c
+@@ -1228,7 +1228,7 @@ simple_object_mach_o_write_segment (simple_object_write *sobj, int descriptor,
+       /* Swap the indices, if required.  */
+ 
+       for (i = 0; i < (nsects_in * 4); ++i)
+-	set_32 (&index[i], index[i]);
++	set_32 ((unsigned char *) &index[i], index[i]);
+ 
+       sechdr_offset += sechdrsize;
+ 


### PR DESCRIPTION
Backport of https://gcc.gnu.org/git/?p=gcc.git;a=blobdiff;f=libiberty/simple-object-mach-o.c;h=a8869e7c63957d86d91d9987bbed40c8284fd253;hp=72b69d19c21627aa29347bc3798aa8f407965fc7;hb=38757aa88735ab2e511bc428e2407a5a5e9fa0be;hpb=6a64964212c8e5e10e474803d06a07514c1069b7

Fixes #189 