### PR TITLE
Add GCC 14.2.0

### DIFF
--- a/hashes/gcc-14.2.0.tar.xz.sha1
+++ b/hashes/gcc-14.2.0.tar.xz.sha1
@@ -1,0 +1,1 @@
+d91ecc3d20ce6298bd95f9b09cc51dc6d3c73ae3  gcc-14.2.0.tar.xz

--- a/patches/gcc-14.2.0/0001-ssp_nonshared.diff
+++ b/patches/gcc-14.2.0/0001-ssp_nonshared.diff
@@ -1,0 +1,14 @@
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 7837553958b..3c81c5798d8 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -980,7 +980,8 @@ proper position among the other output files.  */
+ #ifndef LINK_SSP_SPEC
+ #ifdef TARGET_LIBC_PROVIDES_SSP
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+-		       "|fstack-protector-strong|fstack-protector-explicit:}"
++		       "|fstack-protector-strong|fstack-protector-explicit" \
++		       ":-lssp_nonshared}"
+ #else
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+ 		       "|fstack-protector-strong|fstack-protector-explicit" \

--- a/patches/gcc-14.2.0/0002-posix_memalign.diff
+++ b/patches/gcc-14.2.0/0002-posix_memalign.diff
@@ -1,0 +1,30 @@
+diff --git a/gcc/config/i386/pmm_malloc.h b/gcc/config/i386/pmm_malloc.h
+index 1b0bfe37852..d7b2b19bb3c 100644
+--- a/gcc/config/i386/pmm_malloc.h
++++ b/gcc/config/i386/pmm_malloc.h
+@@ -27,12 +27,13 @@
+ #include <stdlib.h>
+ 
+ /* We can't depend on <stdlib.h> since the prototype of posix_memalign
+-   may not be visible.  */
++   may not be visible and we can't pollute the namespace either.  */
+ #ifndef __cplusplus
+-extern int posix_memalign (void **, size_t, size_t);
++extern int _mm_posix_memalign (void **, size_t, size_t)
+ #else
+-extern "C" int posix_memalign (void **, size_t, size_t) throw ();
++extern "C" int _mm_posix_memalign (void **, size_t, size_t) throw ()
+ #endif
++__asm__("posix_memalign");
+ 
+ static __inline void *
+ _mm_malloc (size_t __size, size_t __alignment)
+@@ -42,7 +43,7 @@ _mm_malloc (size_t __size, size_t __alignment)
+     return malloc (__size);
+   if (__alignment == 2 || (sizeof (void *) == 8 && __alignment == 4))
+     __alignment = sizeof (void *);
+-  if (posix_memalign (&__ptr, __alignment, __size) == 0)
++  if (_mm_posix_memalign (&__ptr, __alignment, __size) == 0)
+     return __ptr;
+   else
+     return NULL;

--- a/patches/gcc-14.2.0/0003-j2.diff
+++ b/patches/gcc-14.2.0/0003-j2.diff
@@ -1,0 +1,346 @@
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 357b0bed067..528add999f2 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -556,7 +556,7 @@ s390*-*-*)
+ 	extra_headers="s390intrin.h htmintrin.h htmxlintrin.h vecintrin.h"
+ 	;;
+ # Note the 'l'; we need to be able to match e.g. "shle" or "shl".
+-sh[123456789lbe]*-*-* | sh-*-*)
++sh[123456789lbej]*-*-* | sh-*-*)
+ 	cpu_type=sh
+ 	extra_options="${extra_options} fused-madd.opt"
+ 	extra_objs="${extra_objs} sh_treg_combine.o sh-mem.o sh_optimize_sett_clrt.o"
+@@ -3202,18 +3202,18 @@ s390x-ibm-tpf*)
+ 	extra_options="${extra_options} s390/tpf.opt"
+ 	tmake_file="${tmake_file} s390/t-s390"
+ 	;;
+-sh-*-elf* | sh[12346l]*-*-elf* | \
+-  sh-*-linux* | sh[2346lbe]*-*-linux* | \
++sh-*-elf* | sh[12346lj]*-*-elf* | \
++  sh-*-linux* | sh[2346lbej]*-*-linux* | \
+   sh-*-netbsdelf* | shl*-*-netbsdelf*)
+ 	tmake_file="${tmake_file} sh/t-sh sh/t-elf"
+ 	if test x${with_endian} = x; then
+ 		case ${target} in
+-		sh[1234]*be-*-* | sh[1234]*eb-*-*) with_endian=big ;;
++		sh[j1234]*be-*-* | sh[j1234]*eb-*-*) with_endian=big ;;
+ 		shbe-*-* | sheb-*-*)		   with_endian=big,little ;;
+ 		sh[1234]l* | sh[34]*-*-linux*)	   with_endian=little ;;
+ 		shl* | sh*-*-linux* | \
+ 		  sh-superh-elf)		   with_endian=little,big ;;
+-		sh[1234]*-*-*)			   with_endian=big ;;
++		sh[j1234]*-*-*)			   with_endian=big ;;
+ 		*)				   with_endian=big,little ;;
+ 		esac
+ 	fi
+@@ -3280,6 +3280,7 @@ sh-*-elf* | sh[12346l]*-*-elf* | \
+ 	sh2a_nofpu*)		sh_cpu_target=sh2a-nofpu ;;
+ 	sh2a*)			sh_cpu_target=sh2a ;;
+ 	sh2e*)			sh_cpu_target=sh2e ;;
++	shj2*)			sh_cpu_target=shj2;;
+ 	sh2*)			sh_cpu_target=sh2 ;;
+ 	*)			sh_cpu_target=sh1 ;;
+ 	esac
+@@ -3301,7 +3302,7 @@ sh-*-elf* | sh[12346l]*-*-elf* | \
+ 	  sh2a-single-only | sh2a-single | sh2a-nofpu | sh2a | \
+ 	  sh4a-single-only | sh4a-single | sh4a-nofpu | sh4a | sh4al | \
+ 	  sh4-single-only | sh4-single | sh4-nofpu | sh4 | sh4-300 | \
+-	  sh3e | sh3 | sh2e | sh2 | sh1) ;;
++	  sh3e | sh3 | sh2e | sh2 | sh1 | shj2) ;;
+ 	"")	sh_cpu_default=${sh_cpu_target} ;;
+ 	*)	echo "with_cpu=$with_cpu not supported"; exit 1 ;;
+ 	esac
+@@ -3310,9 +3311,9 @@ sh-*-elf* | sh[12346l]*-*-elf* | \
+ 		case ${target} in
+ 		sh[1234]*)	sh_multilibs=${sh_cpu_target} ;;
+ 		sh-superh-*)	sh_multilibs=m4,m4-single,m4-single-only,m4-nofpu ;;
+-		sh*-*-linux*)	sh_multilibs=m1,m2,m2a,m3e,m4 ;;
++		sh*-*-linux*)	sh_multilibs=m1,m2,m2a,m3e,m4,mj2 ;;
+ 		sh*-*-netbsd*)	sh_multilibs=m3,m3e,m4 ;;
+-		*) sh_multilibs=m1,m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single ;;
++		*) sh_multilibs=m1,m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single,mj2 ;;
+ 		esac
+ 		if test x$with_fp = xno; then
+ 			sh_multilibs="`echo $sh_multilibs|sed -e s/m4/sh4-nofpu/ -e s/,m4-[^,]*//g -e s/,m[23]e// -e s/m2a,m2a-single/m2a-nofpu/ -e s/m5-..m....,//g`"
+@@ -3327,7 +3328,8 @@ sh-*-elf* | sh[12346l]*-*-elf* | \
+ 		m1 | m2 | m2e | m3 | m3e | \
+ 		m4 | m4-single | m4-single-only | m4-nofpu | m4-300 |\
+ 		m4a | m4a-single | m4a-single-only | m4a-nofpu | m4al | \
+-		m2a | m2a-single | m2a-single-only | m2a-nofpu)
++		m2a | m2a-single | m2a-single-only | m2a-nofpu | \
++		mj2)
+ 			# TM_MULTILIB_CONFIG is used by t-sh for the non-endian multilib definition
+ 			# It is passed to MULTIILIB_OPTIONS verbatim.
+ 			TM_MULTILIB_CONFIG="${TM_MULTILIB_CONFIG}/${sh_multilib}"
+@@ -3344,7 +3346,7 @@ sh-*-elf* | sh[12346l]*-*-elf* | \
+ 	done
+ 	TM_MULTILIB_CONFIG=`echo $TM_MULTILIB_CONFIG | sed 's:^/::'`
+ 	if test x${enable_incomplete_targets} = xyes ; then
+-		tm_defines="$tm_defines SUPPORT_SH1=1 SUPPORT_SH2E=1 SUPPORT_SH4=1 SUPPORT_SH4_SINGLE=1 SUPPORT_SH2A=1 SUPPORT_SH2A_SINGLE=1"
++		tm_defines="$tm_defines SUPPORT_SH1=1 SUPPORT_SH2E=1 SUPPORT_SH4=1 SUPPORT_SH4_SINGLE=1 SUPPORT_SH2A=1 SUPPORT_SH2A_SINGLE=1 SUPPORT_SHJ2=1"
+ 	fi
+ 	tm_file="$tm_file ./sysroot-suffix.h"
+ 	tmake_file="$tmake_file t-sysroot-suffix"
+@@ -5175,6 +5177,8 @@ case "${target}" in
+ 			;;
+ 		m4a | m4a-single | m4a-single-only | m4a-nofpu | m4al)
+ 		        ;;
++		mj2)
++			;;
+ 		*)
+ 			echo "Unknown CPU used in --with-cpu=$with_cpu, known values:"  1>&2
+ 			echo "m1 m2 m2e m3 m3e m4 m4-single m4-single-only m4-nofpu" 1>&2
+@@ -5385,7 +5389,7 @@ case ${target} in
+ 		tmake_file="${cpu_type}/t-${cpu_type} ${tmake_file}"
+ 		;;
+ 
+-	sh[123456ble]*-*-* | sh-*-*)
++	sh[123456blej]*-*-* | sh-*-*)
+ 		c_target_objs="${c_target_objs} sh-c.o"
+ 		cxx_target_objs="${cxx_target_objs} sh-c.o"
+ 		;;
+diff --git a/gcc/config/sh/sh.cc b/gcc/config/sh/sh.cc
+index 1564109c942..798c1c1c1a3 100644
+--- a/gcc/config/sh/sh.cc
++++ b/gcc/config/sh/sh.cc
+@@ -686,6 +686,7 @@ parse_validate_atomic_model_option (const char* str)
+   model_names[sh_atomic_model::hard_llcs] = "hard-llcs";
+   model_names[sh_atomic_model::soft_tcb] = "soft-tcb";
+   model_names[sh_atomic_model::soft_imask] = "soft-imask";
++  model_names[sh_atomic_model::hard_cas] = "hard-cas";
+ 
+   const char* model_cdef_names[sh_atomic_model::num_models];
+   model_cdef_names[sh_atomic_model::none] = "NONE";
+@@ -693,6 +694,7 @@ parse_validate_atomic_model_option (const char* str)
+   model_cdef_names[sh_atomic_model::hard_llcs] = "HARD_LLCS";
+   model_cdef_names[sh_atomic_model::soft_tcb] = "SOFT_TCB";
+   model_cdef_names[sh_atomic_model::soft_imask] = "SOFT_IMASK";
++  model_cdef_names[sh_atomic_model::hard_cas] = "HARD_CAS";
+ 
+   sh_atomic_model ret;
+   ret.type = sh_atomic_model::none;
+@@ -771,6 +773,9 @@ got_mode_name:;
+   if (ret.type == sh_atomic_model::soft_imask && TARGET_USERMODE)
+     err_ret ("cannot use atomic model %s in user mode", ret.name);
+ 
++  if (ret.type == sh_atomic_model::hard_cas && !TARGET_SHJ2)
++    err_ret ("atomic model %s is only available J2 targets", ret.name);
++
+   return ret;
+ 
+ #undef err_ret
+@@ -827,6 +832,8 @@ sh_option_override (void)
+     sh_cpu = PROCESSOR_SH2E;
+   if (TARGET_SH2A)
+     sh_cpu = PROCESSOR_SH2A;
++  if (TARGET_SHJ2)
++    sh_cpu = PROCESSOR_SHJ2;
+   if (TARGET_SH3)
+     sh_cpu = PROCESSOR_SH3;
+   if (TARGET_SH3E)
+diff --git a/gcc/config/sh/sh.h b/gcc/config/sh/sh.h
+index d2280e2ffe6..3a54a896721 100644
+--- a/gcc/config/sh/sh.h
++++ b/gcc/config/sh/sh.h
+@@ -85,6 +85,7 @@ extern int code_for_indirect_jump_scratch;
+ #define SUPPORT_SH4_SINGLE 1
+ #define SUPPORT_SH2A 1
+ #define SUPPORT_SH2A_SINGLE 1
++#define SUPPORT_SHJ2 1
+ #endif
+ 
+ #define TARGET_DIVIDE_CALL_DIV1 (sh_div_strategy == SH_DIV_CALL_DIV1)
+@@ -117,6 +118,7 @@ extern int code_for_indirect_jump_scratch;
+ #define SELECT_SH4A_SINGLE_ONLY  (MASK_SH4A | SELECT_SH4_SINGLE_ONLY)
+ #define SELECT_SH4A		 (MASK_SH4A | SELECT_SH4)
+ #define SELECT_SH4A_SINGLE	 (MASK_SH4A | SELECT_SH4_SINGLE)
++#define SELECT_SHJ2		 (MASK_SHJ2 | SELECT_SH2)
+ 
+ #if SUPPORT_SH1
+ #define SUPPORT_SH2 1
+@@ -124,6 +126,7 @@ extern int code_for_indirect_jump_scratch;
+ #if SUPPORT_SH2
+ #define SUPPORT_SH3 1
+ #define SUPPORT_SH2A_NOFPU 1
++#define SUPPORT_SHJ2 1
+ #endif
+ #if SUPPORT_SH3
+ #define SUPPORT_SH4_NOFPU 1
+@@ -156,7 +159,7 @@ extern int code_for_indirect_jump_scratch;
+ #define MASK_ARCH (MASK_SH1 | MASK_SH2 | MASK_SH3 | MASK_SH_E | MASK_SH4 \
+ 		   | MASK_HARD_SH2A | MASK_HARD_SH2A_DOUBLE | MASK_SH4A \
+ 		   | MASK_HARD_SH4 | MASK_FPU_SINGLE \
+-		   | MASK_FPU_SINGLE_ONLY)
++		   | MASK_FPU_SINGLE_ONLY | MASK_SHJ2)
+ 
+ /* This defaults us to big-endian.  */
+ #ifndef TARGET_ENDIAN_DEFAULT
+@@ -231,7 +234,8 @@ extern int code_for_indirect_jump_scratch;
+ %{m2a-single:--isa=sh2a} \
+ %{m2a-single-only:--isa=sh2a} \
+ %{m2a-nofpu:--isa=sh2a-nofpu} \
+-%{m4al:-dsp}"
++%{m4al:-dsp} \
++%{mj2:-isa=j2}"
+ 
+ #define ASM_SPEC SH_ASM_SPEC
+ 
+@@ -347,6 +351,7 @@ struct sh_atomic_model
+     hard_llcs,
+     soft_tcb,
+     soft_imask,
++    hard_cas,
+ 
+     num_models
+   };
+@@ -390,6 +395,9 @@ extern const sh_atomic_model& selected_atomic_model (void);
+ #define TARGET_ATOMIC_SOFT_IMASK \
+   (selected_atomic_model ().type == sh_atomic_model::soft_imask)
+ 
++#define TARGET_ATOMIC_HARD_CAS \
++  (selected_atomic_model ().type == sh_atomic_model::hard_cas)
++
+ #endif // __cplusplus
+ 
+ #define SUBTARGET_OVERRIDE_OPTIONS (void) 0
+@@ -1484,7 +1492,7 @@ extern bool current_function_interrupt;
+ 
+ /* Nonzero if the target supports dynamic shift instructions
+    like shad and shld.  */
+-#define TARGET_DYNSHIFT (TARGET_SH3 || TARGET_SH2A)
++#define TARGET_DYNSHIFT (TARGET_SH3 || TARGET_SH2A || TARGET_SHJ2)
+ 
+ /* The cost of using the dynamic shift insns (shad, shld) are the same
+    if they are available.  If they are not available a library function will
+@@ -1747,6 +1755,7 @@ enum processor_type {
+   PROCESSOR_SH2,
+   PROCESSOR_SH2E,
+   PROCESSOR_SH2A,
++  PROCESSOR_SHJ2,
+   PROCESSOR_SH3,
+   PROCESSOR_SH3E,
+   PROCESSOR_SH4,
+diff --git a/gcc/config/sh/sh.opt b/gcc/config/sh/sh.opt
+index b4755a812f3..0989a1c18da 100644
+--- a/gcc/config/sh/sh.opt
++++ b/gcc/config/sh/sh.opt
+@@ -65,6 +65,10 @@ m2e
+ Target RejectNegative Condition(SUPPORT_SH2E)
+ Generate SH2e code.
+ 
++mj2
++Target RejectNegative Mask(SHJ2) Condition(SUPPORT_SHJ2)
++Generate J2 code.
++
+ m3
+ Target RejectNegative Mask(SH3) Condition(SUPPORT_SH3)
+ Generate SH3 code.
+diff --git a/gcc/config/sh/sync.md b/gcc/config/sh/sync.md
+index 2b43f8edb86..118fc5d06db 100644
+--- a/gcc/config/sh/sync.md
++++ b/gcc/config/sh/sync.md
+@@ -240,6 +240,9 @@
+       || (TARGET_SH4A && <MODE>mode == SImode && !TARGET_ATOMIC_STRICT))
+     atomic_insn = gen_atomic_compare_and_swap<mode>_hard (old_val, mem,
+ 							  exp_val, new_val);
++  else if (TARGET_ATOMIC_HARD_CAS && <MODE>mode == SImode)
++    atomic_insn = gen_atomic_compare_and_swap<mode>_cas (old_val, mem,
++							 exp_val, new_val);
+   else if (TARGET_ATOMIC_SOFT_GUSA)
+     atomic_insn = gen_atomic_compare_and_swap<mode>_soft_gusa (old_val, mem,
+ 		      exp_val, new_val);
+@@ -306,6 +309,57 @@
+ }
+   [(set_attr "length" "14")])
+ 
++(define_expand "atomic_compare_and_swapsi_cas"
++  [(set (match_operand:SI 0 "register_operand" "=r")
++	(unspec_volatile:SI
++	  [(match_operand:SI 1 "atomic_mem_operand_0" "=Sra")
++	   (match_operand:SI 2 "register_operand" "r")
++	   (match_operand:SI 3 "register_operand" "r")]
++	  UNSPECV_CMPXCHG_1))]
++  "TARGET_ATOMIC_HARD_CAS"
++{
++  rtx mem = gen_rtx_REG (SImode, 0);
++  emit_move_insn (mem, force_reg (SImode, XEXP (operands[1], 0)));
++  emit_insn (gen_shj2_cas (operands[0], mem, operands[2], operands[3]));
++  DONE;
++})
++
++(define_insn "shj2_cas"
++  [(set (match_operand:SI 0 "register_operand" "=&r")
++  (unspec_volatile:SI
++   [(match_operand:SI 1 "register_operand" "=r")
++   (match_operand:SI 2 "register_operand" "r")
++   (match_operand:SI 3 "register_operand" "0")]
++   UNSPECV_CMPXCHG_1))
++   (set (reg:SI T_REG)
++	(unspec_volatile:SI [(const_int 0)] UNSPECV_CMPXCHG_3))]
++  "TARGET_ATOMIC_HARD_CAS"
++  "cas.l	%2,%0,@%1"
++  [(set_attr "length" "2")]
++)
++
++(define_expand "atomic_compare_and_swapqi_cas"
++  [(set (match_operand:SI 0 "arith_reg_dest" "=&r")
++	(unspec_volatile:SI
++	  [(match_operand:SI 1 "atomic_mem_operand_0" "=Sra")
++	   (match_operand:SI 2 "arith_operand" "rI08")
++	   (match_operand:SI 3 "arith_operand" "rI08")]
++	  UNSPECV_CMPXCHG_1))]
++  "TARGET_ATOMIC_HARD_CAS"
++{FAIL;}
++)
++
++(define_expand "atomic_compare_and_swaphi_cas"
++  [(set (match_operand:SI 0 "arith_reg_dest" "=&r")
++	(unspec_volatile:SI
++	  [(match_operand:SI 1 "atomic_mem_operand_0" "=Sra")
++	   (match_operand:SI 2 "arith_operand" "rI08")
++	   (match_operand:SI 3 "arith_operand" "rI08")]
++	  UNSPECV_CMPXCHG_1))]
++  "TARGET_ATOMIC_HARD_CAS"
++{FAIL;}
++)
++
+ ;; The QIHImode llcs patterns modify the address register of the memory
+ ;; operand.  In order to express that, we have to open code the memory
+ ;; operand.  Initially the insn is expanded like every other atomic insn
+diff --git a/gcc/config/sh/t-sh b/gcc/config/sh/t-sh
+index 888f8ff7f25..29fd6ae45fd 100644
+--- a/gcc/config/sh/t-sh
++++ b/gcc/config/sh/t-sh
+@@ -50,7 +50,8 @@ MULTILIB_MATCHES = $(shell \
+              m2e,m3e,m4-single-only,m4-100-single-only,m4-200-single-only,m4-300-single-only,m4a-single-only \
+              m2a-single,m2a-single-only \
+              m4-single,m4-100-single,m4-200-single,m4-300-single,m4a-single \
+-             m4,m4-100,m4-200,m4-300,m4a; do \
++             m4,m4-100,m4-200,m4-300,m4a \
++             mj2; do \
+     subst= ; \
+     for lib in `echo $$abi|tr , ' '` ; do \
+       if test "`echo $$multilibs|sed s/$$lib//`" != "$$multilibs"; then \
+@@ -63,9 +64,9 @@ MULTILIB_MATCHES = $(shell \
+ 
+ # SH1 and SH2A support big endian only.
+ ifeq ($(DEFAULT_ENDIAN),ml)
+-MULTILIB_EXCEPTIONS = m1 ml/m1 m2a* ml/m2a* $(TM_MULTILIB_EXCEPTIONS_CONFIG)
++MULTILIB_EXCEPTIONS = m1 ml/m1 m2a* ml/m2a* ml/mj2 $(TM_MULTILIB_EXCEPTIONS_CONFIG)
+ else
+-MULTILIB_EXCEPTIONS = ml/m1 ml/m2a* $(TM_MULTILIB_EXCEPTIONS_CONFIG)
++MULTILIB_EXCEPTIONS = ml/m1 ml/m2a* ml/mj2 $(TM_MULTILIB_EXCEPTIONS_CONFIG)
+ endif
+ 
+ MULTILIB_OSDIRNAMES = \
+@@ -87,7 +88,8 @@ MULTILIB_OSDIRNAMES = \
+ 	m4a-single-only=!m4a-single-only $(OTHER_ENDIAN)/m4a-single-only=!$(OTHER_ENDIAN)/m4a-single-only \
+ 	m4a-single=!m4a-single $(OTHER_ENDIAN)/m4a-single=!$(OTHER_ENDIAN)/m4a-single \
+ 	m4a=!m4a $(OTHER_ENDIAN)/m4a=!$(OTHER_ENDIAN)/m4a \
+-	m4al=!m4al $(OTHER_ENDIAN)/m4al=!$(OTHER_ENDIAN)/m4al
++	m4al=!m4al $(OTHER_ENDIAN)/m4al=!$(OTHER_ENDIAN)/m4al \
++	mj2=!j2
+ 
+ $(out_object_file): gt-sh.h
+ gt-sh.h : s-gtype ; @true

--- a/patches/gcc-14.2.0/0004-static-pie.diff
+++ b/patches/gcc-14.2.0/0004-static-pie.diff
@@ -1,0 +1,92 @@
+diff --git a/gcc/common.opt b/gcc/common.opt
+index a75b44ee47e..7c564818b49 100644
+--- a/gcc/common.opt
++++ b/gcc/common.opt
+@@ -3473,11 +3473,11 @@ Driver
+ 
+ no-pie
+ Driver RejectNegative Negative(shared)
+-Don't create a dynamically linked position independent executable.
++Don't create a position independent executable.
+ 
+ pie
+ Driver RejectNegative Negative(no-pie)
+-Create a dynamically linked position independent executable.
++Create a position independent executable.
+ 
+ static-pie
+ Driver RejectNegative Negative(pie)
+diff --git a/gcc/config/gnu-user.h b/gcc/config/gnu-user.h
+index 5ebbf42a13d..bb907d8e89a 100644
+--- a/gcc/config/gnu-user.h
++++ b/gcc/config/gnu-user.h
+@@ -51,13 +51,12 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ #define GNU_USER_TARGET_STARTFILE_SPEC \
+   "%{shared:; \
+      pg|p|profile:%{static-pie:grcrt1.o%s;:gcrt1.o%s}; \
+-     static:crt1.o%s; \
+-     static-pie:rcrt1.o%s; \
++     static|static-pie:%{" PIE_SPEC ":rcrt1.o%s;:crt1.o%s}; \
+      " PIE_SPEC ":Scrt1.o%s; \
+      :crt1.o%s} " \
+    GNU_USER_TARGET_CRTI " \
+-   %{static:crtbeginT.o%s; \
+-     shared|static-pie|" PIE_SPEC ":crtbeginS.o%s; \
++   %{shared|" PIE_SPEC ":crtbeginS.o%s; \
++     static:crtbeginT.o%s; \
+      :crtbegin.o%s} \
+    %{fvtable-verify=none:%s; \
+      fvtable-verify=preinit:vtv_start_preinit.o%s; \
+@@ -73,11 +72,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    GNU userspace "finalizer" file, `crtn.o'.  */
+ 
+ #define GNU_USER_TARGET_ENDFILE_SPEC \
+-  "%{!static:%{fvtable-verify=none:%s; \
++  "%{static|static-pie:; \
++     fvtable-verify=none:%s; \
+      fvtable-verify=preinit:vtv_end_preinit.o%s; \
+-     fvtable-verify=std:vtv_end.o%s}} \
+-   %{static:crtend.o%s; \
+-     shared|static-pie|" PIE_SPEC ":crtendS.o%s; \
++     fvtable-verify=std:vtv_end.o%s} \
++   %{shared|" PIE_SPEC ":crtendS.o%s; \
+      :crtend.o%s} " \
+    GNU_USER_TARGET_CRTN " " \
+    CRTOFFLOADEND
+@@ -106,7 +105,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ #define LIB_SPEC GNU_USER_TARGET_LIB_SPEC
+ 
+ #if defined(HAVE_LD_EH_FRAME_HDR)
+-#define LINK_EH_SPEC "%{!static|static-pie:--eh-frame-hdr} "
++#define LINK_EH_SPEC "%{!static|" PIE_SPEC ":--eh-frame-hdr} "
+ #endif
+ 
+ #define GNU_USER_TARGET_LINK_GCC_C_SEQUENCE_SPEC \
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 3c81c5798d8..cd96eac5d12 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -1010,7 +1010,7 @@ proper position among the other output files.  */
+ #define NO_FPIE_AND_FPIC_SPEC	NO_FPIE_SPEC "|" NO_FPIC_SPEC
+ #define FPIE_OR_FPIC_SPEC	NO_FPIE_AND_FPIC_SPEC ":;"
+ #else
+-#define PIE_SPEC		"pie"
++#define PIE_SPEC		"pie|static-pie"
+ #define FPIE1_SPEC		"fpie"
+ #define NO_FPIE1_SPEC		FPIE1_SPEC ":;"
+ #define FPIE2_SPEC		"fPIE"
+@@ -1034,12 +1034,12 @@ proper position among the other output files.  */
+ #ifndef LINK_PIE_SPEC
+ #ifdef HAVE_LD_PIE
+ #ifndef LD_PIE_SPEC
+-#define LD_PIE_SPEC "-pie"
++#define LD_PIE_SPEC "-pie %{static|static-pie:--no-dynamic-linker -z text -Bsymbolic}"
+ #endif
+ #else
+ #define LD_PIE_SPEC ""
+ #endif
+-#define LINK_PIE_SPEC "%{static|shared|r:;" PIE_SPEC ":" LD_PIE_SPEC "} "
++#define LINK_PIE_SPEC "%{shared|r:;" PIE_SPEC ":" LD_PIE_SPEC "} "
+ #endif
+ 
+ #ifndef LINK_BUILDID_SPEC

--- a/patches/gcc-14.2.0/0005-m68k-sqrt.diff
+++ b/patches/gcc-14.2.0/0005-m68k-sqrt.diff
@@ -1,0 +1,20 @@
+diff --git a/gcc/config/m68k/m68k.md b/gcc/config/m68k/m68k.md
+index 59a456cd496..dbfddea41bd 100644
+--- a/gcc/config/m68k/m68k.md
++++ b/gcc/config/m68k/m68k.md
+@@ -4174,13 +4174,13 @@
+ (define_expand "sqrt<mode>2"
+   [(set (match_operand:FP 0 "nonimmediate_operand" "")
+ 	(sqrt:FP (match_operand:FP 1 "general_operand" "")))]
+-  "TARGET_HARD_FLOAT"
++  "(TARGET_68881 && TARGET_68040) || TARGET_COLDFIRE_FPU"
+   "")
+ 
+ (define_insn "sqrt<mode>2_68881"
+   [(set (match_operand:FP 0 "nonimmediate_operand" "=f")
+ 	(sqrt:FP (match_operand:FP 1 "general_operand" "f<FP:dreg>m")))]
+-  "TARGET_68881"
++  "TARGET_68881 && TARGET_68040"
+ {
+   if (FP_REG_P (operands[1]))
+     return "f<FP:round>sqrt%.x %1,%0";

--- a/patches/gcc-14.2.0/0006-cow-libstdc++v3.diff
+++ b/patches/gcc-14.2.0/0006-cow-libstdc++v3.diff
@@ -1,0 +1,8 @@
+--- a/libstdc++-v3/ChangeLog	2024-03-13 18:04:21.050801063 -0400
++++ b/libstdc++-v3/ChangeLog	2024-03-13 18:04:25.665836804 -0400
+@@ -4068,4 +4068,4 @@
+ 
+ Copying and distribution of this file, with or without modification,
+ are permitted in any medium without royalty provided the copyright
+-notice and this notice are preserved.
++notice and this notice are preserved.

--- a/patches/gcc-14.2.0/0007-fdpic-unwind.diff
+++ b/patches/gcc-14.2.0/0007-fdpic-unwind.diff
@@ -1,0 +1,11 @@
+--- a/libgcc/unwind-pe.h	2024-03-14 05:59:53.754073149 +0900
++++ b/libgcc/unwind-pe.h	2024-03-14 06:00:41.226074492 +0900
+@@ -262,7 +262,7 @@
+ 
+       if (result != 0)
+ 	{
+-#if __FDPIC__
++#if __FDPIC__ && __arm__
+ 	  /* FDPIC relative addresses imply taking the GOT address
+ 	     into account.  */
+ 	  if ((encoding & DW_EH_PE_pcrel) && (encoding & DW_EH_PE_indirect))

--- a/patches/gcc-14.2.0/0008-fdpic-crtstuff-pr114158.diff
+++ b/patches/gcc-14.2.0/0008-fdpic-crtstuff-pr114158.diff
@@ -1,0 +1,38 @@
+--- a/libgcc/crtstuff.c	2023-05-29 17:46:32.000000000 +0900
++++ b/libgcc/crtstuff.c	2024-03-14 06:03:42.398079615 +0900
+@@ -441,17 +441,9 @@
+ #ifdef FINI_SECTION_ASM_OP
+ CRT_CALL_STATIC_FUNCTION (FINI_SECTION_ASM_OP, __do_global_dtors_aux)
+ #elif defined (FINI_ARRAY_SECTION_ASM_OP)
+-#if defined(__FDPIC__)
+-__asm__("\t.equ\t__do_global_dtors_aux_alias, __do_global_dtors_aux\n");
+-extern char __do_global_dtors_aux_alias;
+-static void *__do_global_dtors_aux_fini_array_entry[]
+-__attribute__ ((__used__, section(".fini_array"), aligned(sizeof(void *))))
+-     = { &__do_global_dtors_aux_alias };
+-#else /* defined(__FDPIC__) */
+ static func_ptr __do_global_dtors_aux_fini_array_entry[]
+   __attribute__ ((__used__, section(".fini_array"),
+ 		  aligned(__alignof__(func_ptr)))) = { __do_global_dtors_aux };
+-#endif /* defined(__FDPIC__) */
+ #else /* !FINI_SECTION_ASM_OP && !FINI_ARRAY_SECTION_ASM_OP */
+ static void __attribute__((used))
+ __do_global_dtors_aux_1 (void)
+@@ -494,17 +486,9 @@
+ #ifdef __LIBGCC_INIT_SECTION_ASM_OP__
+ CRT_CALL_STATIC_FUNCTION (__LIBGCC_INIT_SECTION_ASM_OP__, frame_dummy)
+ #else /* defined(__LIBGCC_INIT_SECTION_ASM_OP__) */
+-#if defined(__FDPIC__)
+-__asm__("\t.equ\t__frame_dummy_alias, frame_dummy\n");
+-extern char __frame_dummy_alias;
+-static void *__frame_dummy_init_array_entry[]
+-__attribute__ ((__used__, section(".init_array"), aligned(sizeof(void *))))
+-     = { &__frame_dummy_alias };
+-#else /* defined(__FDPIC__) */
+ static func_ptr __frame_dummy_init_array_entry[]
+   __attribute__ ((__used__, section(".init_array"),
+ 		  aligned(__alignof__(func_ptr)))) = { frame_dummy };
+-#endif /* defined(__FDPIC__) */
+ #endif /* !defined(__LIBGCC_INIT_SECTION_ASM_OP__) */
+ #endif /* USE_EH_FRAME_REGISTRY || USE_TM_CLONE_REGISTRY */
+ 

--- a/patches/gcc-14.2.0/0009-sh-fdpic-pr114641.diff
+++ b/patches/gcc-14.2.0/0009-sh-fdpic-pr114641.diff
@@ -1,0 +1,12 @@
+--- gcc-11.4.0/gcc/config/sh/sh.cc.orig	2024-04-04 05:52:42.125373614 +0900
++++ gcc-11.4.0/gcc/config/sh/sh.cc	2024-04-04 22:54:01.875106654 +0900
+@@ -9147,7 +9147,7 @@
+ 	{
+ 	  /* Weak functions may be NULL which doesn't work with
+ 	     GOTOFFFUNCDESC because the runtime offset is not known.  */
+-	  if (SYMBOL_REF_WEAK (orig))
++	  if (SYMBOL_REF_WEAK (orig) || (TREE_PUBLIC(SYMBOL_REF_DECL(orig)) && DECL_VISIBILITY (SYMBOL_REF_DECL(orig)) != VISIBILITY_HIDDEN))
+ 	    emit_insn (gen_symGOTFUNCDESC2reg (reg, orig));
+ 	  else
+ 	    emit_insn (gen_symGOTOFFFUNCDESC2reg (reg, orig));
+


### PR DESCRIPTION
The only update needed for the gcc-11.2 patches to cleanly apply were changing filenames due to GCC's C++ adoption:

gcc.c -> gcc.cc
sh.c -> sh.cc