### PR TITLE
add support config.sub a2287c3041a3

### DIFF
--- a/hashes/config.sub.a2287c3041a3.sha1
+++ b/hashes/config.sub.a2287c3041a3.sha1
@@ -1,0 +1,1 @@
+3adf4069b9eb2c9d90b98ba533b006dc49a008cf  config.sub


### PR DESCRIPTION
Add hash for tested to work config.sub HEAD with sha a2287c30, at the time of this pull request.

There is no specific convention mentioned for the length of the sha, with the default 3d5db9ebe860 being 12 characters. This URL says 8-10 is sufficient,

https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1