### PR TITLE
add support Linux kernel 6.15.7

### DIFF
--- a/hashes/linux-6.15.7.tar.xz.sha1
+++ b/hashes/linux-6.15.7.tar.xz.sha1
@@ -1,0 +1,1 @@
+d97af2fed36305f0e7b24167baae9c8fcc7a01ec  linux-6.15.7.tar.xz


### PR DESCRIPTION
added support for tested to work major.minor versions of the linux kernel version. Skipping patch versions versions