### PR TITLE
fix binutils-2.44 sha1 format

### DIFF
--- a/hashes/binutils-2.44.tar.gz.sha1
+++ b/hashes/binutils-2.44.tar.gz.sha1
@@ -1,1 +1,1 @@
-568ba0a286cf79520572c1597a203c1aafd462de binutils-2.44.tar.gz
+568ba0a286cf79520572c1597a203c1aafd462de  binutils-2.44.tar.gz


### PR DESCRIPTION
Currently, building from `master` fails due to a bad SHA1 format in the checksum file, using `shasum -a 1 -c`:
```
cd sources/linux-headers-4.19.88-2.tar.xz.tmp && shasum -a 1 -c /home/angt/.tmp/musl-cross-make/hashes/linux-headers-4.19.88-2.tar.xz.sha1
shasum: /home/angt/.tmp/musl-cross-make/hashes/binutils-2.44.tar.gz.sha1: no properly formatted SHA checksum lines found
make: *** [Makefile:90: sources/binutils-2.44.tar.gz] Error 1
```
