### PR TITLE
Add GCC 15.1 COBOL (libgcobol) musl compatibility patch

### DIFF
--- a/patches/gcc-15.1.0/0010-libgcobol-musl-execinfo.diff
+++ b/patches/gcc-15.1.0/0010-libgcobol-musl-execinfo.diff
@@ -1,0 +1,14 @@
+diff --git a/libgcobol/libgcobol.cc b/libgcobol/libgcobol.cc
+index 1234567..abcdefg 100644
+--- a/libgcobol/libgcobol.cc
++++ b/libgcobol/libgcobol.cc
+@@ -65,7 +65,9 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
+
+ #include "exceptl.h"
+


### PR DESCRIPTION
I was bored today and tried some COBOL that was recently merged and released in GCC 15.1. After non successful static linking using glibc, I just tried to compile it with my usual goto musl-cross-make, that succeeded using the patch attached.

So if someone else is in search on how to fully statically link COBOL programs, the patch may help. The patch was not yet submitted upstream.

Some config hints:
```
# Configuration for GCC 15.1 with COBOL support

TARGET = x86_64-linux-musl

# Use GCC 15.1.0 (includes COBOL frontend)
GCC_VER = 15.1.0

# Enable C, C++, and COBOL languages
GCC_CONFIG += --enable-languages=c,c++,cobol
```

Simple Hello World seems to be around 672 KB after stripping.

---
This patch adds musl libc support for GCC 15.1's new COBOL frontend by making the execinfo.h include conditional on HAVE_EXECINFO_H.

Background:
- GCC 15.1 introduced native COBOL support (gcobol compiler)
- libgcobol unconditionally included <execinfo.h>, a glibc-specific header
- musl libc does not provide execinfo.h (backtrace functions)
- The header was included but never actually used in the code

This patch:
- Guards the execinfo.h include with #ifdef HAVE_EXECINFO_H
- Allows libgcobol to build successfully with musl
- No functional changes (execinfo.h was not used)
- Enables fully static COBOL binaries via musl

Tested with:
- GCC 15.1.0
- musl 1.2.5
- Target: x86_64-linux-musl
- Successfully compiles and runs COBOL programs